### PR TITLE
Fix athenaclirc not in path issue

### DIFF
--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -64,7 +64,7 @@ class AthenaCli(object):
                  s3_staging_dir, athenaclirc, profile, database):
 
         config_files = [DEFAULT_CONFIG_FILE]
-        if os.path.exists(athenaclirc):
+        if os.path.exists(os.path.expanduser(ATHENACLIRC)):
             config_files.append(athenaclirc)
         _cfg = self.config = read_config_files(config_files)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,5 @@
 (Unreleased; add upcoming change notes here)
-* Add support for `role_arn` in athenaclirc file to allow connection to assume 
-aws role
+* Fix bug: athenaclirc not found if not in path
 ==============================================
 
 1.4.0


### PR DESCRIPTION
## Description
Fixes bug where athenaclirc file is no longer found if not in path

## Checklist
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
